### PR TITLE
Consistent formatting when saving files

### DIFF
--- a/term.Rproj
+++ b/term.Rproj
@@ -12,6 +12,9 @@ Encoding: UTF-8
 RnwWeave: knitr
 LaTeX: pdfLaTeX
 
+AutoAppendNewline: Yes
+StripTrailingWhitespace: Yes
+
 BuildType: Package
 PackageUseDevtools: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source


### PR DESCRIPTION
Ensures spaces at EOL are stripped, and a newline is added before EOF.