### PR TITLE
Hide params from documentation index

### DIFF
--- a/R/params.R
+++ b/R/params.R
@@ -13,10 +13,11 @@
 #'
 #' @param value A character vector of the new parameter names.
 #' @param pars A character vector of parameter names.
-#' @param scalar A logical scalar specifying whether to include 
+#' @param scalar A logical scalar specifying whether to include
 #' all parameters (NA), only scalars (TRUE) or all parameters
 #' except scalars (FALSE).
 #' @param incomparables Ignored.
 #'
 #' @name params
+#' @keywords internal
 NULL

--- a/man/params.Rd
+++ b/man/params.Rd
@@ -31,3 +31,4 @@ except scalars (FALSE).}
 \description{
 Parameter Descriptions for term Functions
 }
+\keyword{internal}


### PR DESCRIPTION
because it seems to be an internal documentation page.