### PR TITLE
Use parseable code in call to lifecycle

### DIFF
--- a/R/deprecated.R
+++ b/R/deprecated.R
@@ -70,8 +70,8 @@ parameters <- function(x, ...) {
 #' @export
 `parameters<-` <- function(x, value) {
   deprecate_soft("0.1.0",
-    what = "parameters<-",
-    with = "pars<-"
+    what = "`parameters<-`()",
+    with = "`pars<-`()"
   )
   pars(x) <- value
   x


### PR DESCRIPTION
I don't think this has ever worked, but lifecycle 1.0.0 forces it to obviously not work
