### PR TITLE
Switch order of equality & condition expectations

### DIFF
--- a/tests/testthat/test-npars.R
+++ b/tests/testthat/test-npars.R
@@ -28,7 +28,7 @@ test_that("npars.term scalar = FALSE", {
 })
 
 test_that("npars.term invalid elements", {
-  expect_identical(expect_warning(npars(new_term(c("a[2]", "b c")))), 2L)
+  expect_warning(expect_identical(npars(new_term(c("a[2]", "b c"))), 2L))
 })
 
 test_that("npars.term missing values", {
@@ -42,7 +42,7 @@ test_that("npars.term scalar", {
 })
 
 test_that("npars.term scalar invalid elements", {
-  expect_identical(expect_warning(npars(new_term(c("a[2]", "b c")), scalar = TRUE)), 1L)
+  expect_warning(expect_identical(npars(new_term(c("a[2]", "b c")), scalar = TRUE), 1L))
 })
 
 test_that("npars scalar missing values", {


### PR DESCRIPTION
In the dev version of testthat, we've tweaked `expect_warning()` and friends to return output that's [more consistent](https://github.com/r-lib/testthat/blob/master/NEWS.md#breaking-changes) with other testthat expectations. We'd like to get testthat on to CRAN in the near future, so I'd really appreciate it if you could merge this change and update your package on CRAN.