### PR TITLE
chore: Bump R dependency, required because extras needs 4.3

### DIFF
--- a/.github/.gitignore
+++ b/.github/.gitignore
@@ -1,1 +1,2 @@
 *.html
+/pkg.lock

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,4 +41,4 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 Language: en-US
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.2.9000

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,7 @@ URL: https://poissonconsulting.github.io/term/,
     https://github.com/poissonconsulting/term
 BugReports: https://github.com/poissonconsulting/term/issues
 Depends: 
-    R (>= 4.0)
+    R (>= 4.3)
 Imports:
     chk,
     extras,


### PR DESCRIPTION
This might be the easiest way to fix CI/CD.