### PR TITLE
fledge: CRAN pre-release v0.3.5.9900

### DIFF
--- a/.github/.gitignore
+++ b/.github/.gitignore
@@ -1,1 +1,2 @@
 *.html
+/pkg.lock

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,4 +41,4 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 Language: en-US
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.2.9000

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: term
 Title: Create, Manipulate and Query Parameter Terms
-Version: 0.3.5.9007
+Version: 0.3.5.9900
 Authors@R: c(
     person("Joe", "Thorley", , "joe@poissonconsulting.ca", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-7683-4592")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,35 +2,12 @@
 
 # term 0.3.5.9900
 
-## Continuous integration
-
-- Avoid failure in fledge workflow if no changes (#63).
-
-- Fetch tags for fledge workflow to avoid unnecessary NEWS entries (#62).
-
-- Use larger retry count for lock-threads workflow (#61).
-
-- Ignore errors when removing pkg-config on macOS (#60).
-
-- Overwrite from actions-sync (#59).
-
-## Uncategorized
-
-- Merge branch 'main' of github.com:poissonconsulting/term.
-
-- Drop chk_s3_class() from documentation.
-
-- Merge pull request #58 from poissonconsulting/upkeep.
-
-  Upkeep
-
-- Same as previous version.
-
+- Require R (>= 4.0).
+- Fixed `chk_s3_class()` reference in documentation that causing CRAN NOTE.
 
 # term 0.3.5
 
-- Requires R (>= 3.5)
-
+- Require R (>= 3.5).
 - Moved following from soft to warn deprecated
  - `is.term()`
  - `is.incomplete_terms()`

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,57 +1,28 @@
 <!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->
 
-# term 0.3.5.9007
-
-- Merge branch 'main' of github.com:poissonconsulting/term.
-
-
-# term 0.3.5.9006
-
-- Drop chk_s3_class() from documentation.
-
-
-# term 0.3.5.9005
+# term 0.3.5.9900
 
 ## Continuous integration
 
 - Avoid failure in fledge workflow if no changes (#63).
 
-
-# term 0.3.5.9004
-
-## Continuous integration
-
 - Fetch tags for fledge workflow to avoid unnecessary NEWS entries (#62).
-
-
-# term 0.3.5.9003
-
-## Continuous integration
 
 - Use larger retry count for lock-threads workflow (#61).
 
-
-# term 0.3.5.9002
-
-## Continuous integration
-
 - Ignore errors when removing pkg-config on macOS (#60).
-
-
-# term 0.3.5.9001
-
-## Continuous integration
 
 - Overwrite from actions-sync (#59).
 
 ## Uncategorized
 
+- Merge branch 'main' of github.com:poissonconsulting/term.
+
+- Drop chk_s3_class() from documentation.
+
 - Merge pull request #58 from poissonconsulting/upkeep.
 
   Upkeep
-
-
-# term 0.3.5.9000
 
 - Same as previous version.
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,20 +1,5 @@
-## Test environments
+term 0.3.5.9900
 
-release 4.2.1
+## Cran Repository Policy
 
-* OSX (local) - release
-* OSX (actions) - release
-* Ubuntu (actions) - 3.5 to 4.1, oldrel, release and devel
-* Windows (actions) - release
-* Windows (winbuilder) - devel
-
-## R CMD check results
-
-0 errors | 0 warnings | 0 notes
-
-## revdepcheck results
-
-We checked 2 reverse dependencies, comparing R CMD check results across CRAN and dev versions of this package.
-
- * We saw 0 new problems
- * We failed to check 0 packages
+- [x] Reviewed CRP last edited 2024-08-27.

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -3,3 +3,22 @@ term 0.3.5.9900
 ## Cran Repository Policy
 
 - [x] Reviewed CRP last edited 2024-08-27.
+
+## CRAN check results
+
+> Result: NOTE 
+  Found the following Rd file(s) with Rd \link{} targets missing package
+  anchors:
+    vld_term.Rd: chk_s3_class
+  Please provide package anchors for all Rd \link{} targets not in the
+  package itself and the base packages.
+Flavors: r-devel-linux-x86_64-debian-clang, r-devel-linux-x86_64-debian-gcc, r-devel-windows-x86_64
+
+Fixed.
+
+## revdepcheck results
+
+We checked all 2 reverse dependencies from CRAN, comparing R CMD check results across CRAN and dev versions of this package.
+
+ * We saw 0 new problems
+ * We failed to check 0 packages


### PR DESCRIPTION
## Current CRAN check results

- [x] Checked on 2025-01-20, problems found: https://cran.r-project.org/web/checks/check_results_term.html
- [x] NOTE: r-devel-linux-x86_64-debian-clang, r-devel-linux-x86_64-debian-gcc, r-devel-windows-x86_64
     Found the following Rd file(s) with Rd \link{} targets missing package
     anchors:
     vld_term.Rd: chk_s3_class
     Please provide package anchors for all Rd \link{} targets not in the
     package itself and the base packages.

Check results at: https://cran.r-project.org/web/checks/check_results_term.html

## Action items

- [x] Review PR
- [x] Await successful CI/CD run
- [ ] Run `fledge::release()`
- [ ] When the package is accepted on CRAN, run `fledge::post_release()`