### PR TITLE
fledge: CRAN release v0.3.6

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: term
 Title: Create, Manipulate and Query Parameter Terms
-Version: 0.3.5.9901
+Version: 0.3.6
 Authors@R: c(
     person("Joe", "Thorley", , "joe@poissonconsulting.ca", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-7683-4592")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,16 +1,16 @@
 <!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->
 
-# term 0.3.5.9901
+# term 0.3.6
 
 ## fledge
 
 - CRAN pre-release v0.3.5.9900 (#67).
 
+## Uncategorized
 
-# term 0.3.5.9900
-
-- Require R (>= 4.0).
+- Require R (\>= 4.0).
 - Fixed `chk_s3_class()` reference in documentation that causing CRAN NOTE.
+
 
 # term 0.3.5
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,14 +2,8 @@
 
 # term 0.3.6
 
-## fledge
-
-- CRAN pre-release v0.3.5.9900 (#67).
-
-## Uncategorized
-
 - Require R (\>= 4.0).
-- Fixed `chk_s3_class()` reference in documentation that causing CRAN NOTE.
+- Fixed `chk_s3_class()` reference in documentation that was causing CRAN NOTE.
 
 
 # term 0.3.5

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,24 +1,5 @@
-term 0.3.5.9900
+term 0.3.6
 
 ## Cran Repository Policy
 
 - [x] Reviewed CRP last edited 2024-08-27.
-
-## CRAN check results
-
-> Result: NOTE 
-  Found the following Rd file(s) with Rd \link{} targets missing package
-  anchors:
-    vld_term.Rd: chk_s3_class
-  Please provide package anchors for all Rd \link{} targets not in the
-  package itself and the base packages.
-Flavors: r-devel-linux-x86_64-debian-clang, r-devel-linux-x86_64-debian-gcc, r-devel-windows-x86_64
-
-Fixed.
-
-## revdepcheck results
-
-We checked all 2 reverse dependencies from CRAN, comparing R CMD check results across CRAN and dev versions of this package.
-
- * We saw 0 new problems
- * We failed to check 0 packages


### PR DESCRIPTION
## Current CRAN check results

- [x] Checked on 2025-01-21, problems found: https://cran.r-project.org/web/checks/check_results_term.html
- [x] NOTE: r-devel-linux-x86_64-debian-clang, r-devel-linux-x86_64-debian-gcc, r-devel-windows-x86_64
     Found the following Rd file(s) with Rd \link{} targets missing package
     anchors:
     vld_term.Rd: chk_s3_class
     Please provide package anchors for all Rd \link{} targets not in the
     package itself and the base packages.

Check results at: https://cran.r-project.org/web/checks/check_results_term.html

## Action items

- [x] Review PR
- [x] Await successful CI/CD run
- [x] Run `fledge::release()`
- [x] When the package is accepted on CRAN, run `fledge::post_release()`