### PR TITLE
chore: Format with air

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -17,3 +17,5 @@
 ^revdep$
 ^CRAN-SUBMISSION$
 ^\.ccache$
+^[.]?air[.]toml$
+^\.vscode$

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "Posit.air-vscode"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+  "[r]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "Posit.air-vscode"
+  },
+  "[quarto]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "quarto.quarto"
+  }
+}

--- a/R/as-data-frame.R
+++ b/R/as-data-frame.R
@@ -3,5 +3,9 @@
 as.data.frame.term_rcrd <- function(x, ..., stringsAsFactors = FALSE) {
   chk_flag(stringsAsFactors)
   # FIXME: Need stringsAsFactors? Use vctrs::new_data_frame()?
-  data.frame(par = field(x, "par"), dim = I(field(x, "dim")), stringsAsFactors = stringsAsFactors)
+  data.frame(
+    par = field(x, "par"),
+    dim = I(field(x, "dim")),
+    stringsAsFactors = stringsAsFactors
+  )
 }

--- a/R/as-term-rcrd.R
+++ b/R/as-term-rcrd.R
@@ -29,7 +29,9 @@ as_term_rcrd.numeric <- function(x, name = "par", ...) {
 as_term_rcrd.term <- function(x, repair = FALSE, ...) {
   chk_flag(repair)
   chk_unused(...)
-  if (repair) x <- repair_terms(x, normalize = FALSE)
+  if (repair) {
+    x <- repair_terms(x, normalize = FALSE)
+  }
   vec_cast(x, new_term_rcrd())
 }
 

--- a/R/chk.R
+++ b/R/chk.R
@@ -17,14 +17,20 @@ chk_term <- function(x, validate = "complete", x_name = NULL) {
   if (vld_term(x, validate = validate)) {
     return(invisible())
   }
-  if (is.null(x_name)) x_name <- deparse_backtick_chk(substitute(x))
+  if (is.null(x_name)) {
+    x_name <- deparse_backtick_chk(substitute(x))
+  }
 
-  if (!is_term(x)) abort_chk(x_name, " must be a term vector")
+  if (!is_term(x)) {
+    abort_chk(x_name, " must be a term vector")
+  }
   x <- x[!is.na(x)]
   if (!all(valid_term(x))) {
     abort_chk("All elements of term vector ", x_name, " must be valid")
   }
-  if (is_inconsistent_terms(x)) abort_chk("All elements of term vector ", x_name, " must be consistent")
+  if (is_inconsistent_terms(x)) {
+    abort_chk("All elements of term vector ", x_name, " must be consistent")
+  }
   abort_chk("All elements of term vector ", x_name, " must be complete")
 }
 
@@ -41,13 +47,23 @@ chk_term_rcrd <- function(x, validate = "complete", x_name = NULL) {
   if (vld_term_rcrd(x, validate = validate)) {
     return(invisible())
   }
-  if (is.null(x_name)) x_name <- deparse_backtick_chk(substitute(x))
+  if (is.null(x_name)) {
+    x_name <- deparse_backtick_chk(substitute(x))
+  }
 
-  if (!is_term_rcrd(x)) abort_chk(x_name, " must be a term_rcrd vector")
+  if (!is_term_rcrd(x)) {
+    abort_chk(x_name, " must be a term_rcrd vector")
+  }
   x <- x[!is.na(x)]
   if (!all(valid_term(x))) {
     abort_chk("All elements of term_rcrd vector ", x_name, " must be valid")
   }
-  if (is_inconsistent_terms(x)) abort_chk("All elements of term_rcrd vector ", x_name, " must be consistent")
+  if (is_inconsistent_terms(x)) {
+    abort_chk(
+      "All elements of term_rcrd vector ",
+      x_name,
+      " must be consistent"
+    )
+  }
   abort_chk("All elements of term_rcrd vector ", x_name, " must be complete")
 }

--- a/R/deprecated.R
+++ b/R/deprecated.R
@@ -7,7 +7,6 @@
 deprecated <- function(...) NULL
 # nocov end
 
-
 #' @describeIn deprecated Is Term
 #'
 #' `r lifecycle::badge("deprecated")`
@@ -15,10 +14,7 @@ deprecated <- function(...) NULL
 #' Replace by [is_term()]
 #' @export
 is.term <- function(x) {
-  deprecate_warn("0.1.0",
-    what = "term::is.term()",
-    with = "term::is_term()"
-  )
+  deprecate_warn("0.1.0", what = "term::is.term()", with = "term::is_term()")
   is_term(x)
 }
 
@@ -29,7 +25,8 @@ is.term <- function(x) {
 #' Replace by [is_incomplete_terms()]
 #' @export
 is.incomplete_terms <- function(x) {
-  deprecate_warn("0.1.0",
+  deprecate_warn(
+    "0.1.0",
     what = "term::is.incomplete_terms()",
     with = "term::is_incomplete_terms()"
   )
@@ -43,7 +40,8 @@ is.incomplete_terms <- function(x) {
 #' Replace by [is_inconsistent_terms()]
 #' @export
 is.inconsistent_terms <- function(x) {
-  deprecate_warn("0.1.0",
+  deprecate_warn(
+    "0.1.0",
     what = "term::is.inconsistent_terms()",
     with = "term::is_inconsistent_terms()"
   )
@@ -57,10 +55,7 @@ is.inconsistent_terms <- function(x) {
 #' Replace by [pars()]
 #' @export
 parameters <- function(x, ...) {
-  deprecate_warn("0.1.0",
-    what = "parameters()",
-    with = "pars()"
-  )
+  deprecate_warn("0.1.0", what = "parameters()", with = "pars()")
   pars(x, ...)
 }
 
@@ -72,10 +67,7 @@ parameters <- function(x, ...) {
 #' Replace by pars<-
 #' @export
 `parameters<-` <- function(x, value) {
-  deprecate_warn("0.1.0",
-    what = "`parameters<-`()",
-    with = "`pars<-`()"
-  )
+  deprecate_warn("0.1.0", what = "`parameters<-`()", with = "`pars<-`()")
   pars(x) <- value
   x
 }
@@ -87,7 +79,8 @@ parameters <- function(x, ...) {
 #' Replace by [set_pars()]
 #' @export
 set_parameters <- function(x, pars) {
-  deprecate_warn("0.1.0",
+  deprecate_warn(
+    "0.1.0",
     what = "term::set_parameters()",
     with = "term::set_pars()"
   )
@@ -101,9 +94,6 @@ set_parameters <- function(x, pars) {
 #' Replace by [tindex()]
 #' @export
 tdims <- function(x) {
-  deprecate_warn("0.1.0",
-    what = "term::tdims()",
-    with = "term::tindex()"
-  )
+  deprecate_warn("0.1.0", what = "term::tdims()", with = "term::tindex()")
   tindex(x)
 }

--- a/R/internal.R
+++ b/R/internal.R
@@ -33,8 +33,12 @@ valid_term_impl <- function(x) {
     return(logical(0))
   }
   pattern <- p0(
-    "^\\s*", par_pattern(), "\\s*(\\[\\s*",
-    .index_pattern, "(\\s*,\\s*", .index_pattern,
+    "^\\s*",
+    par_pattern(),
+    "\\s*(\\[\\s*",
+    .index_pattern,
+    "(\\s*,\\s*",
+    .index_pattern,
     ")*\\s*\\]){0,1}\\s*$"
   )
   valid <- grepl(pattern, x)
@@ -46,8 +50,12 @@ pars_terms_impl <- function(x, scalar = NULL) {
   scalar_term <- scalar_term_impl(x)
   x <- as.character(x)
   x <- sub(p0("^(", par_pattern(), ")(.*)"), "\\1", x)
-  if (vld_true(scalar)) x <- x[scalar_term]
-  if (vld_false(scalar)) x <- x[!scalar_term]
+  if (vld_true(scalar)) {
+    x <- x[scalar_term]
+  }
+  if (vld_false(scalar)) {
+    x <- x[!scalar_term]
+  }
   x
 }
 
@@ -67,7 +75,8 @@ term_impl <- function(args) {
 
   args[numbers] <- mapply(
     term_from_pdims,
-    number_args, names2(number_args),
+    number_args,
+    names2(number_args),
     SIMPLIFY = FALSE
   )
 

--- a/R/new-term-rcrd.R
+++ b/R/new-term-rcrd.R
@@ -14,7 +14,9 @@
 #' ))
 #' }
 #' @export
-new_term_rcrd <- function(x = data.frame(par = character(), dim = I(list()), stringsAsFactors = FALSE)) {
+new_term_rcrd <- function(
+  x = data.frame(par = character(), dim = I(list()), stringsAsFactors = FALSE)
+) {
   chk_data(x)
   check_names(x, c("par", "dim"))
   x$dim <- as_list_unnamed_default(x$dim)

--- a/R/pars.R
+++ b/R/pars.R
@@ -74,8 +74,12 @@ pars.term <- function(x, scalar = NULL, terms = FALSE, ...) {
 #' pars(term, scalar = FALSE)
 pars.term_rcrd <- function(x, scalar = NULL, ...) {
   # FIXME hack for nlist v0.1.0 and v0.1.1
-  if (identical(scalar, NA)) scalar <- NULL
-  if (!is.null(scalar)) chk_flag(scalar)
+  if (identical(scalar, NA)) {
+    scalar <- NULL
+  }
+  if (!is.null(scalar)) {
+    chk_flag(scalar)
+  }
   chk_unused(...)
 
   if (!is.null(scalar)) {

--- a/R/pdims.R
+++ b/R/pdims.R
@@ -12,7 +12,9 @@ universals::pdims
 #' @examples
 #' pdims(term("alpha[1]", "alpha[3]", "beta[1,1]", "beta[2,1]"))
 pdims.term <- function(x, ...) {
-  if (anyNA(x)) abort_chk("`x` must not have any missing values")
+  if (anyNA(x)) {
+    abort_chk("`x` must not have any missing values")
+  }
   if (is_inconsistent_terms(x)) {
     abort_chk("`x` must have terms with consistent parameter dimensions")
   }

--- a/R/set-pars.R
+++ b/R/set-pars.R
@@ -18,7 +18,12 @@ set_pars.term <- function(x, value, ...) {
   chk_unused(...)
 
   if (!identical(npars(x), length(value))) {
-    abort_chk("`value` must be length ", npars(x), ", not %n.", n = length(value))
+    abort_chk(
+      "`value` must be length ",
+      npars(x),
+      ", not %n.",
+      n = length(value)
+    )
   }
 
   if (!length(x)) {

--- a/R/subset.R
+++ b/R/subset.R
@@ -22,7 +22,8 @@ subset.term <- function(x, pars = NULL, select = NULL, ...) {
 
   if (!missing(select)) {
     deprecate_warn(
-      "0.3.7", "term::subset(select =)",
+      "0.3.7",
+      "term::subset(select =)",
       "term::subset(pars =)"
     )
   }
@@ -31,7 +32,8 @@ subset.term <- function(x, pars = NULL, select = NULL, ...) {
     chk_subset(select, pars(x))
     if (!is.null(pars)) {
       deprecate_stop(
-        "0.1.1", "term::subset(select =)",
+        "0.1.1",
+        "term::subset(select =)",
         "term::subset(pars =)"
       )
     }

--- a/R/term.R
+++ b/R/term.R
@@ -36,13 +36,15 @@ term <- function(...) {
   compat_args <- exec(term_compat_args, !!!args)
   if (is.numeric(compat_args$x) && all(compat_args$x != 0)) {
     lifecycle::deprecate_warn(
-      "0.3.7", "term::term(x =)",
+      "0.3.7",
+      "term::term(x =)",
       details = "Use named arguments to pass integer dimensions."
     )
     term <- term_impl(list2(!!compat_args$name := compat_args$x))
   } else if (is.list(compat_args$x)) {
     lifecycle::deprecate_warn(
-      "0.3.7", "term::term(x =)",
+      "0.3.7",
+      "term::term(x =)",
       details = "Use named arguments directly, or splice a list as in `term(!!!x)`."
     )
     term <- term_impl(compat_args$x)

--- a/R/tindex.R
+++ b/R/tindex.R
@@ -17,7 +17,8 @@
 tindex <- function(x) {
   if (!is_term(x) && !is_term_rcrd(x)) {
     lifecycle::deprecate_warn(
-      "0.3.7", "term::tindex(x = 'must be a term or term_rcrd object')"
+      "0.3.7",
+      "term::tindex(x = 'must be a term or term_rcrd object')"
     )
     x <- as_term(x)
   }

--- a/R/vld.R
+++ b/R/vld.R
@@ -31,7 +31,9 @@
 vld_term <- function(x, validate = "complete") {
   chk_string(validate)
   if (validate == "class") {
-    deprecate_warn("0.3.7", "term::vld_term(validate =)",
+    deprecate_warn(
+      "0.3.7",
+      "term::vld_term(validate =)",
       details = "More specifically the 'class' value of the `validate` argument has been deprecated for `vld_s3_class(class = 'term')` and the default value of validate has been replaced by 'complete'"
     )
   }

--- a/air.toml
+++ b/air.toml
@@ -1,0 +1,7 @@
+[format]
+line-width = 80
+indent-width = 2
+indent-style = "space"
+line-ending = "auto"
+persistent-line-breaks = true
+default-exclude = true

--- a/scripts/build.R
+++ b/scripts/build.R
@@ -5,9 +5,11 @@ styler::style_pkg(
   filetype = c("R", "Rmd")
 )
 
-lintr::lint_package(linters = linters_with_defaults(
-  line_length_linter = line_length_linter(1000),
-  object_name_linter = object_name_linter(regexes = ".*"))
+lintr::lint_package(
+  linters = linters_with_defaults(
+    line_length_linter = line_length_linter(1000),
+    object_name_linter = object_name_linter(regexes = ".*")
+  )
 )
 
 lintr::lint_package()

--- a/scripts/rcrd.R
+++ b/scripts/rcrd.R
@@ -30,7 +30,10 @@ x <- new_list_of(list(1:3, 2:1), integer(), class = "term_dim")
 inherits(x, "list")
 vec_is(x)
 
-xx <- new_rcrd(fields = list(name = letters[1:2], dim = x), class = "term_rcrd2")
+xx <- new_rcrd(
+  fields = list(name = letters[1:2], dim = x),
+  class = "term_rcrd2"
+)
 vec_is(xx)
 term::term(!!!set_names(field(xx, "dim"), field(xx, "name")))
 xx
@@ -48,4 +51,3 @@ vec_cast(xx, new_term())
 x <- structure(list(1:3, 2:1), class = c("term_rcrd", "list"))
 inherits(x, "list")
 vec_is(x)
-

--- a/scripts/rethink.R
+++ b/scripts/rethink.R
@@ -2,11 +2,11 @@
 
 # term vectors can be readily created from a numeric object
 library(term)
-as_term(matrix(c(1,5,6,10), nrow = 2))
+as_term(matrix(c(1, 5, 6, 10), nrow = 2))
 
 # or from multiple numeric objects
 library(nlist)
-nlist <- nlist(x = c(3,6,9), zz = matrix(c(1, 5, 6, 11), nrow = 2))
+nlist <- nlist(x = c(3, 6, 9), zz = matrix(c(1, 5, 6, 11), nrow = 2))
 nlist
 as_term(nlist)
 
@@ -23,7 +23,7 @@ as_nlist(mcmc)
 
 # its important to note that elements can be missing, duplicated, inconsistent
 
-mcmc <- mcmc[,-c(2,7),drop = FALSE]
+mcmc <- mcmc[, -c(2, 7), drop = FALSE]
 
 mcmc
 
@@ -35,5 +35,3 @@ as_nlist(mcmc)
 #
 # the question is whether its worth defining each element in a term vector as a composite of scalars of other class (possibly vctr_vctrs) one class is the parameter
 # name and the other is the index which must be a 1 or more positive integers?
-
-

--- a/tests/testthat/test-anyduplicated.R
+++ b/tests/testthat/test-anyduplicated.R
@@ -2,15 +2,27 @@ test_that("anyDuplicated term", {
   expect_identical(anyDuplicated(new_term()), 0L)
   expect_identical(anyDuplicated(new_term(c("alpha[1]"))), 0L)
   expect_identical(anyDuplicated(new_term(c("alpha[1]", "alpha[1]"))), 2L)
-  expect_identical(anyDuplicated(new_term(c("alpha[1]", "alpha[1]", "alpha[1]"))), 2L)
+  expect_identical(
+    anyDuplicated(new_term(c("alpha[1]", "alpha[1]", "alpha[1]"))),
+    2L
+  )
   expect_identical(anyDuplicated(new_term(c("alpha[1]", "alpha"))), 2L)
   expect_identical(anyDuplicated(new_term(c("alpha[1]", "alpha1"))), 0L)
   expect_identical(anyDuplicated(new_term(c("alpha[1]", NA_term_))), 0L)
-  expect_identical(anyDuplicated(new_term(c("alpha[1]", NA_term_, NA_term_))), 3L)
+  expect_identical(
+    anyDuplicated(new_term(c("alpha[1]", NA_term_, NA_term_))),
+    3L
+  )
 })
 
 test_that("anyDuplicated term_rcrd", {
   expect_identical(anyDuplicated(new_term_rcrd()), 0L)
-  expect_identical(anyDuplicated(as_term_rcrd(new_term(c("alpha[1]", "alpha")))), 2L)
-  expect_identical(anyDuplicated(as_term_rcrd(new_term(c("alpha[1]", NA_term_, NA_term_)))), 3L)
+  expect_identical(
+    anyDuplicated(as_term_rcrd(new_term(c("alpha[1]", "alpha")))),
+    2L
+  )
+  expect_identical(
+    anyDuplicated(as_term_rcrd(new_term(c("alpha[1]", NA_term_, NA_term_)))),
+    3L
+  )
 })

--- a/tests/testthat/test-as-term-rcrd.R
+++ b/tests/testthat/test-as-term-rcrd.R
@@ -1,12 +1,19 @@
 test_that("as_term_rcrd.term", {
-  expect_identical(as_term_rcrd(as_term("x[1]")), new_term_rcrd(data.frame(
-    par = "x", dim = I(list(1L)),
-    stringsAsFactors = FALSE
-  )))
+  expect_identical(
+    as_term_rcrd(as_term("x[1]")),
+    new_term_rcrd(data.frame(
+      par = "x",
+      dim = I(list(1L)),
+      stringsAsFactors = FALSE
+    ))
+  )
 })
 
 test_that("as_term_rcrd.integer", {
-  expect_identical(as_term_rcrd(1L, name = "par"), as_term_rcrd(as_term("par[1]")))
+  expect_identical(
+    as_term_rcrd(1L, name = "par"),
+    as_term_rcrd(as_term("par[1]"))
+  )
   expect_identical(
     as_term_rcrd(c(1L, 4L), name = "par"),
     as_term_rcrd(as_term(c("par[1]", "par[2]")))
@@ -37,8 +44,18 @@ test_that("as_term_rcrd.matrix", {
   expect_identical(
     as_term_rcrd(matrix(1:12, c(3, 4)), "t"),
     as_term_rcrd(as_term(c(
-      "t[1,1]", "t[2,1]", "t[3,1]", "t[1,2]", "t[2,2]",
-      "t[3,2]", "t[1,3]", "t[2,3]", "t[3,3]", "t[1,4]", "t[2,4]", "t[3,4]"
+      "t[1,1]",
+      "t[2,1]",
+      "t[3,1]",
+      "t[1,2]",
+      "t[2,2]",
+      "t[3,2]",
+      "t[1,3]",
+      "t[2,3]",
+      "t[3,3]",
+      "t[1,4]",
+      "t[2,4]",
+      "t[3,4]"
     )))
   )
 })
@@ -51,17 +68,38 @@ test_that("as_term_rcrd.array", {
   expect_identical(
     as_term_rcrd(array(1:12, c(2, 3, 2)), "t"),
     as_term_rcrd(as_term(c(
-      "t[1,1,1]", "t[2,1,1]", "t[1,2,1]", "t[2,2,1]", "t[1,3,1]",
-      "t[2,3,1]", "t[1,1,2]", "t[2,1,2]", "t[1,2,2]", "t[2,2,2]", "t[1,3,2]",
+      "t[1,1,1]",
+      "t[2,1,1]",
+      "t[1,2,1]",
+      "t[2,2,1]",
+      "t[1,3,1]",
+      "t[2,3,1]",
+      "t[1,1,2]",
+      "t[2,1,2]",
+      "t[1,2,2]",
+      "t[2,2,2]",
+      "t[1,3,2]",
       "t[2,3,2]"
     )))
   )
 })
 
 test_that("as_term_rcrd.character", {
-  expect_error(as_term_rcrd("a", "b"), "^`repair` must be a flag [(]TRUE or FALSE[)][.]$", class = "chk_error")
-  x <- c("parm3[10]", "parm3[2]", "parm[2,2]", "parm[1,1]", "parm[2,1]", "parm[1,2]", "parm[10]", "parm3")
-
+  expect_error(
+    as_term_rcrd("a", "b"),
+    "^`repair` must be a flag [(]TRUE or FALSE[)][.]$",
+    class = "chk_error"
+  )
+  x <- c(
+    "parm3[10]",
+    "parm3[2]",
+    "parm[2,2]",
+    "parm[1,1]",
+    "parm[2,1]",
+    "parm[1,2]",
+    "parm[10]",
+    "parm3"
+  )
 
   expect_identical(
     as_term_rcrd(c("a", "a[", NA, "a[1]")),
@@ -77,7 +115,19 @@ test_that("as_term_rcrd.character", {
   expect_s3_class(x2, "term_rcrd")
   expect_true(is_term_rcrd(x2))
   x3 <- as.character(x2)
-  expect_identical(x3, c("parm3[10]", "parm3[2]", "parm[2,2]", "parm[1,1]", "parm[2,1]", "parm[1,2]", "parm[10]", "parm3[1]"))
+  expect_identical(
+    x3,
+    c(
+      "parm3[10]",
+      "parm3[2]",
+      "parm[2,2]",
+      "parm[1,1]",
+      "parm[2,1]",
+      "parm[1,2]",
+      "parm[10]",
+      "parm3[1]"
+    )
+  )
 
   expect_identical(pars_terms(x2), c(rep("parm3", 2), rep("parm", 5), "parm3"))
   #  expect_identical(x2 > x2, rep(FALSE, length(x2)))
@@ -97,8 +147,15 @@ test_that("as_term_rcrd others", {
 })
 
 test_that("as_term_rcrd missing values", {
-  expect_identical(as_term_rcrd(NA_term_), structure(list(par = NA_character_, dim = list(NA_integer_)), class = c(
-    "term_rcrd",
-    "vctrs_rcrd", "vctrs_vctr"
-  )))
+  expect_identical(
+    as_term_rcrd(NA_term_),
+    structure(
+      list(par = NA_character_, dim = list(NA_integer_)),
+      class = c(
+        "term_rcrd",
+        "vctrs_rcrd",
+        "vctrs_vctr"
+      )
+    )
+  )
 })

--- a/tests/testthat/test-as-term.R
+++ b/tests/testthat/test-as-term.R
@@ -30,8 +30,18 @@ test_that("as_term.matrix", {
   expect_identical(
     as_term(matrix(1:12, c(3, 4)), "t"),
     new_term(c(
-      "t[1,1]", "t[2,1]", "t[3,1]", "t[1,2]", "t[2,2]",
-      "t[3,2]", "t[1,3]", "t[2,3]", "t[3,3]", "t[1,4]", "t[2,4]", "t[3,4]"
+      "t[1,1]",
+      "t[2,1]",
+      "t[3,1]",
+      "t[1,2]",
+      "t[2,2]",
+      "t[3,2]",
+      "t[1,3]",
+      "t[2,3]",
+      "t[3,3]",
+      "t[1,4]",
+      "t[2,4]",
+      "t[3,4]"
     ))
   )
 })
@@ -44,16 +54,38 @@ test_that("as_term.array", {
   expect_identical(
     as_term(array(1:12, c(2, 3, 2)), "t"),
     new_term(c(
-      "t[1,1,1]", "t[2,1,1]", "t[1,2,1]", "t[2,2,1]", "t[1,3,1]",
-      "t[2,3,1]", "t[1,1,2]", "t[2,1,2]", "t[1,2,2]", "t[2,2,2]", "t[1,3,2]",
+      "t[1,1,1]",
+      "t[2,1,1]",
+      "t[1,2,1]",
+      "t[2,2,1]",
+      "t[1,3,1]",
+      "t[2,3,1]",
+      "t[1,1,2]",
+      "t[2,1,2]",
+      "t[1,2,2]",
+      "t[2,2,2]",
+      "t[1,3,2]",
       "t[2,3,2]"
     ))
   )
 })
 
 test_that("as_term.character", {
-  expect_error(as_term("a", "b"), "^`repair` must be a flag [(]TRUE or FALSE[)][.]$", class = "chk_error")
-  x <- c("parm3[10]", "parm3[2]", "parm[2,2]", "parm[1,1]", "parm[2,1]", "parm[1,2]", "parm[10]", "parm3")
+  expect_error(
+    as_term("a", "b"),
+    "^`repair` must be a flag [(]TRUE or FALSE[)][.]$",
+    class = "chk_error"
+  )
+  x <- c(
+    "parm3[10]",
+    "parm3[2]",
+    "parm[2,2]",
+    "parm[1,1]",
+    "parm[2,1]",
+    "parm[1,2]",
+    "parm[10]",
+    "parm3"
+  )
 
   expect_identical(as_term("1"), new_term("1"))
   expect_identical(as_term("1", repair = TRUE), new_term(NA_character_))
@@ -78,18 +110,31 @@ test_that("as_term.character", {
   expect_identical(
     tindex(x2),
     list(
-      `parm3[10]` = 10L, `parm3[2]` = 2L,
-      `parm[2,2]` = c(2L, 2L), `parm[1,1]` = c(1L, 1L),
-      `parm[2,1]` = 2:1, `parm[1,2]` = 1:2,
-      `parm[10]` = 10L, `parm3` = 1L
+      `parm3[10]` = 10L,
+      `parm3[2]` = 2L,
+      `parm[2,2]` = c(2L, 2L),
+      `parm[1,1]` = c(1L, 1L),
+      `parm[2,1]` = 2:1,
+      `parm[1,2]` = 1:2,
+      `parm[10]` = 10L,
+      `parm3` = 1L
     )
   )
   expect_identical(x2 > x2, rep(FALSE, length(x2)))
 
-  expect_identical(sort(x2), new_term(c(
-    "parm[10]", "parm[1,1]", "parm[2,1]", "parm[1,2]",
-    "parm[2,2]", "parm3", "parm3[2]", "parm3[10]"
-  )))
+  expect_identical(
+    sort(x2),
+    new_term(c(
+      "parm[10]",
+      "parm[1,1]",
+      "parm[2,1]",
+      "parm[1,2]",
+      "parm[2,2]",
+      "parm3",
+      "parm3[2]",
+      "parm3[10]"
+    ))
+  )
 
   expect_identical(as_term(x2), x2)
 })

--- a/tests/testthat/test-chk.R
+++ b/tests/testthat/test-chk.R
@@ -4,13 +4,29 @@ test_that("chk_term", {
   expect_null(chk_term(new_term(c("x[2]", "x[1]"))))
 
   x <- c("x[2]", "x[1]")
-  expect_error(chk_term(x), "^`x` must be a term vector[.]$", class = "chk_error")
+  expect_error(
+    chk_term(x),
+    "^`x` must be a term vector[.]$",
+    class = "chk_error"
+  )
   x <- new_term(c("x[2]", "x[1"))
-  expect_error(chk_term(x, validate = "valid"), "^All elements of term vector `x` must be valid[.]$", class = "chk_error")
+  expect_error(
+    chk_term(x, validate = "valid"),
+    "^All elements of term vector `x` must be valid[.]$",
+    class = "chk_error"
+  )
   x <- new_term(c("x[2]", "x[1,1]"))
-  expect_error(chk_term(x, validate = "consistent"), "^All elements of term vector `x` must be consistent[.]$", class = "chk_error")
+  expect_error(
+    chk_term(x, validate = "consistent"),
+    "^All elements of term vector `x` must be consistent[.]$",
+    class = "chk_error"
+  )
   x <- new_term(c("x[2,2]", "x[1,1]"))
-  expect_error(chk_term(x, validate = "complete"), "^All elements of term vector `x` must be complete[.]$", class = "chk_error")
+  expect_error(
+    chk_term(x, validate = "complete"),
+    "^All elements of term vector `x` must be complete[.]$",
+    class = "chk_error"
+  )
 })
 
 test_that("chk_term_rcrd", {
@@ -19,9 +35,21 @@ test_that("chk_term_rcrd", {
   expect_null(chk_term_rcrd(term_rcrd(c("x[2]", "x[1]"))))
 
   x <- c("x[2]", "x[1]")
-  expect_error(chk_term_rcrd(x), "^`x` must be a term_rcrd vector[.]$", class = "chk_error")
+  expect_error(
+    chk_term_rcrd(x),
+    "^`x` must be a term_rcrd vector[.]$",
+    class = "chk_error"
+  )
   x <- term_rcrd(c("x[2]", "x[1,1]"))
-  expect_error(chk_term_rcrd(x, validate = "consistent"), "^All elements of term_rcrd vector `x` must be consistent[.]$", class = "chk_error")
+  expect_error(
+    chk_term_rcrd(x, validate = "consistent"),
+    "^All elements of term_rcrd vector `x` must be consistent[.]$",
+    class = "chk_error"
+  )
   x <- term_rcrd(c("x[2,2]", "x[1,1]"))
-  expect_error(chk_term_rcrd(x, validate = "complete"), "^All elements of term_rcrd vector `x` must be complete[.]$", class = "chk_error")
+  expect_error(
+    chk_term_rcrd(x, validate = "complete"),
+    "^All elements of term_rcrd vector `x` must be complete[.]$",
+    class = "chk_error"
+  )
 })

--- a/tests/testthat/test-complete-terms.R
+++ b/tests/testthat/test-complete-terms.R
@@ -1,5 +1,7 @@
 test_that("complete_terms term", {
-  expect_error(complete_terms(NA_term_), "^`x` must not have any missing values[.]$",
+  expect_error(
+    complete_terms(NA_term_),
+    "^`x` must not have any missing values[.]$",
     class = "chk_error"
   )
   expect_identical(complete_terms(new_term()), new_term())
@@ -16,12 +18,16 @@ test_that("complete_terms term", {
     complete_terms(new_term(c("b", "b[3]"))),
     new_term(c("b[1]", "b[3]", "b[2]"))
   )
-  expect_identical(complete_terms(new_term("b[3]")), new_term(c("b[3]", "b[1]", "b[2]")))
+  expect_identical(
+    complete_terms(new_term("b[3]")),
+    new_term(c("b[3]", "b[1]", "b[2]"))
+  )
   expect_identical(
     complete_terms(new_term(c("z[2,2]", "z[2,1]"))),
     new_term(c("z[2,2]", "z[2,1]", "z[1,1]", "z[1,2]"))
   )
-  expect_error(complete_terms(new_term(c("b", "b[2,2]"))),
+  expect_error(
+    complete_terms(new_term(c("b", "b[2,2]"))),
     "`x` must have terms with consistent parameter dimensions.",
     class = "chk_error"
   )
@@ -35,19 +41,26 @@ test_that("complete_terms term_rcrd", {
     class = "chk_error"
   )
   expect_identical(complete_terms(term_rcrd("b")), term_rcrd("b"))
-  expect_identical(complete_terms(term_rcrd(c("b", "b"))), term_rcrd(c("b", "b")))
+  expect_identical(
+    complete_terms(term_rcrd(c("b", "b"))),
+    term_rcrd(c("b", "b"))
+  )
   expect_identical(complete_terms(term_rcrd("b")), term_rcrd("b"))
   expect_identical(complete_terms(term_rcrd("b[1]")), term_rcrd("b"))
   expect_identical(
     complete_terms(term_rcrd(c("b", "b[3]"))),
     term_rcrd(c("b[1]", "b[3]", "b[2]"))
   )
-  expect_identical(complete_terms(term_rcrd("b[3]")), term_rcrd(c("b[3]", "b[1]", "b[2]")))
+  expect_identical(
+    complete_terms(term_rcrd("b[3]")),
+    term_rcrd(c("b[3]", "b[1]", "b[2]"))
+  )
   expect_identical(
     complete_terms(term_rcrd(c("z[2,2]", "z[2,1]"))),
     term_rcrd(c("z[2,2]", "z[2,1]", "z[1,1]", "z[1,2]"))
   )
-  expect_error(complete_terms(term_rcrd(c("b", "b[2,2]"))),
+  expect_error(
+    complete_terms(term_rcrd(c("b", "b[2,2]"))),
     "`x` must have terms with consistent parameter dimensions.",
     class = "chk_error"
   )

--- a/tests/testthat/test-consistent-term.R
+++ b/tests/testthat/test-consistent-term.R
@@ -1,5 +1,7 @@
 test_that("consistent_term", {
-  expect_error(consistent_term(1), "`x` must inherit from S3 class 'term'.",
+  expect_error(
+    consistent_term(1),
+    "`x` must inherit from S3 class 'term'.",
     class = "chk_error"
   )
   expect_identical(consistent_term(new_term()), logical(0))
@@ -9,15 +11,29 @@ test_that("consistent_term", {
   expect_identical(consistent_term(new_term(c("a", "a[1]"))), c(TRUE, TRUE))
   expect_identical(consistent_term(new_term(c("a", "a[2]"))), c(TRUE, TRUE))
   expect_identical(consistent_term(new_term(c("a[10]", "a[2]"))), c(TRUE, TRUE))
-  expect_identical(consistent_term(new_term(c("a[2]", "a[2,1]"))), c(FALSE, FALSE))
-  expect_identical(consistent_term(new_term(c("a[1,1]", "a[2,1]"))), c(TRUE, TRUE))
-  expect_identical(consistent_term(new_term(c("a[1,1]", "a[2,1]", "a["))), c(TRUE, TRUE, NA))
-  expect_identical(consistent_term(new_term(c("a[1,1]", "a[2,1]", "a[", "b"))), c(TRUE, TRUE, NA, TRUE))
+  expect_identical(
+    consistent_term(new_term(c("a[2]", "a[2,1]"))),
+    c(FALSE, FALSE)
+  )
+  expect_identical(
+    consistent_term(new_term(c("a[1,1]", "a[2,1]"))),
+    c(TRUE, TRUE)
+  )
+  expect_identical(
+    consistent_term(new_term(c("a[1,1]", "a[2,1]", "a["))),
+    c(TRUE, TRUE, NA)
+  )
+  expect_identical(
+    consistent_term(new_term(c("a[1,1]", "a[2,1]", "a[", "b"))),
+    c(TRUE, TRUE, NA, TRUE)
+  )
   expect_identical(consistent_term(new_term("a[")), NA)
 })
 
 test_that("consistent_term term_rcrd", {
-  expect_error(consistent_term(1), "`x` must inherit from S3 class 'term_rcrd'.",
+  expect_error(
+    consistent_term(1),
+    "`x` must inherit from S3 class 'term_rcrd'.",
     class = "chk_error"
   )
   expect_identical(consistent_term(term_rcrd()), logical(0))
@@ -26,7 +42,16 @@ test_that("consistent_term term_rcrd", {
   expect_identical(consistent_term(term_rcrd(c("a", "a"))), c(TRUE, TRUE))
   expect_identical(consistent_term(term_rcrd(c("a", "a[1]"))), c(TRUE, TRUE))
   expect_identical(consistent_term(term_rcrd(c("a", "a[2]"))), c(TRUE, TRUE))
-  expect_identical(consistent_term(term_rcrd(c("a[10]", "a[2]"))), c(TRUE, TRUE))
-  expect_identical(consistent_term(term_rcrd(c("a[2]", "a[2,1]"))), c(FALSE, FALSE))
-  expect_identical(consistent_term(term_rcrd(c("a[1,1]", "a[2,1]"))), c(TRUE, TRUE))
+  expect_identical(
+    consistent_term(term_rcrd(c("a[10]", "a[2]"))),
+    c(TRUE, TRUE)
+  )
+  expect_identical(
+    consistent_term(term_rcrd(c("a[2]", "a[2,1]"))),
+    c(FALSE, FALSE)
+  )
+  expect_identical(
+    consistent_term(term_rcrd(c("a[1,1]", "a[2,1]"))),
+    c(TRUE, TRUE)
+  )
 })

--- a/tests/testthat/test-inconsistent-terms.R
+++ b/tests/testthat/test-inconsistent-terms.R
@@ -8,7 +8,12 @@ test_that("is_inconsistent_terms term", {
   expect_false(is_inconsistent_terms(new_term("b[1]")))
   expect_false(is_inconsistent_terms(new_term("b[2]")))
   expect_false(is_inconsistent_terms(new_term(c("b[2]", "b"))))
-  expect_false(is_inconsistent_terms(new_term(c("a[1,1]", "a[1,2]", "a[2,1]", "a[2,2]"))))
+  expect_false(is_inconsistent_terms(new_term(c(
+    "a[1,1]",
+    "a[1,2]",
+    "a[2,1]",
+    "a[2,2]"
+  ))))
   expect_false(is_inconsistent_terms(new_term(c("a[1,1]", "a[1,2]", "a[2,1]"))))
 })
 
@@ -21,6 +26,15 @@ test_that("is_inconsistent_terms term_rcrd", {
   expect_false(is_inconsistent_terms(term_rcrd("b[1]")))
   expect_false(is_inconsistent_terms(term_rcrd("b[2]")))
   expect_false(is_inconsistent_terms(term_rcrd(c("b[2]", "b"))))
-  expect_false(is_inconsistent_terms(term_rcrd(c("a[1,1]", "a[1,2]", "a[2,1]", "a[2,2]"))))
-  expect_false(is_inconsistent_terms(term_rcrd(c("a[1,1]", "a[1,2]", "a[2,1]"))))
+  expect_false(is_inconsistent_terms(term_rcrd(c(
+    "a[1,1]",
+    "a[1,2]",
+    "a[2,1]",
+    "a[2,2]"
+  ))))
+  expect_false(is_inconsistent_terms(term_rcrd(c(
+    "a[1,1]",
+    "a[1,2]",
+    "a[2,1]"
+  ))))
 })

--- a/tests/testthat/test-internal.R
+++ b/tests/testthat/test-internal.R
@@ -17,14 +17,27 @@ test_that("npdims_terms_impl", {
   )
 
   expect_identical(
-    npdims_terms_impl(as_term_rcrd(new_term(c("alpha[1]", "alpha[3]", "beta[1,1]", "beta[2,1]")))),
+    npdims_terms_impl(as_term_rcrd(new_term(c(
+      "alpha[1]",
+      "alpha[3]",
+      "beta[1,1]",
+      "beta[2,1]"
+    )))),
     c(alpha = 1L, alpha = 1L, beta = 2L, beta = 2L)
   )
 
   expect_identical(
-    npdims_terms_impl(as_term_rcrd(new_term(c("beta[1,1]", "alpha[1]", "alpha[3]", "beta[10]")))),
+    npdims_terms_impl(as_term_rcrd(new_term(c(
+      "beta[1,1]",
+      "alpha[1]",
+      "alpha[3]",
+      "beta[10]"
+    )))),
     c(beta = 2L, alpha = 1L, alpha = 1L, beta = 1L)
   )
 
-  expect_identical(npdims_terms_impl(as_term_rcrd(NA_term_)), rlang::set_names(NA_integer_, NA_character_))
+  expect_identical(
+    npdims_terms_impl(as_term_rcrd(NA_term_)),
+    rlang::set_names(NA_integer_, NA_character_)
+  )
 })

--- a/tests/testthat/test-is-incomplete-terms.R
+++ b/tests/testthat/test-is-incomplete-terms.R
@@ -14,6 +14,11 @@ test_that("is_incomplete_terms", {
   expect_false(is_incomplete_terms(new_term(c("b[1]", "b[1]", "b[2]"))))
   expect_false(is_incomplete_terms(new_term(c("b[1]", "b[1]", "b[2]", "b[2]"))))
   expect_false(is_incomplete_terms(new_term(c("b", "b[1]", "b[2]"))))
-  expect_false(is_incomplete_terms(new_term(c("a[1,1]", "a[1,2]", "a[2,1]", "a[2,2]"))))
+  expect_false(is_incomplete_terms(new_term(c(
+    "a[1,1]",
+    "a[1,2]",
+    "a[2,1]",
+    "a[2,2]"
+  ))))
   expect_true(is_incomplete_terms(new_term(c("a[1,1]", "a[1,2]", "a[2,1]"))))
 })

--- a/tests/testthat/test-new-term-rcrd.R
+++ b/tests/testthat/test-new-term-rcrd.R
@@ -1,19 +1,34 @@
 test_that("new_term_rcrd", {
   expect_identical(
     new_term_rcrd(),
-    structure(list(par = character(0), dim = list()), class = c(
-      "term_rcrd",
-      "vctrs_rcrd", "vctrs_vctr"
-    ))
+    structure(
+      list(par = character(0), dim = list()),
+      class = c(
+        "term_rcrd",
+        "vctrs_rcrd",
+        "vctrs_vctr"
+      )
+    )
   )
   expect_identical(
     new_term_rcrd(data.frame(
-      par = c("x", "x", "y"), dim = I(list(1, 2, c(2, 2))),
+      par = c("x", "x", "y"),
+      dim = I(list(1, 2, c(2, 2))),
       stringsAsFactors = FALSE
     )),
-    structure(list(par = c("x", "x", "y"), dim = list(1, 2, c(
-      2,
-      2
-    ))), class = c("term_rcrd", "vctrs_rcrd", "vctrs_vctr"))
+    structure(
+      list(
+        par = c("x", "x", "y"),
+        dim = list(
+          1,
+          2,
+          c(
+            2,
+            2
+          )
+        )
+      ),
+      class = c("term_rcrd", "vctrs_rcrd", "vctrs_vctr")
+    )
   )
 })

--- a/tests/testthat/test-normalize-terms.R
+++ b/tests/testthat/test-normalize-terms.R
@@ -1,6 +1,15 @@
 test_that("multiplication works", {
-  expect_identical(normalize_terms(new_term(c("b", "b[3]"))), as_term(c("b[1]", "b[3]")))
-  expect_identical(normalize_terms(new_term(c("b[1]", "a[3]"))), as_term(c("b", "a[3]")))
+  expect_identical(
+    normalize_terms(new_term(c("b", "b[3]"))),
+    as_term(c("b[1]", "b[3]"))
+  )
+  expect_identical(
+    normalize_terms(new_term(c("b[1]", "a[3]"))),
+    as_term(c("b", "a[3]"))
+  )
   expect_identical(normalize_terms(new_term()), as_term(character(0)))
-  expect_identical(normalize_terms(new_term(c("b[3]", NA))), as_term(c("b[3]", NA)))
+  expect_identical(
+    normalize_terms(new_term(c("b[3]", NA))),
+    as_term(c("b[3]", NA))
+  )
 })

--- a/tests/testthat/test-npars.R
+++ b/tests/testthat/test-npars.R
@@ -1,8 +1,13 @@
 test_that("npars.term", {
   expect_identical(
     npars(new_term(c(
-      "alpha[1]", "alpha[2]", "beta[1,1]", "beta[2,1]",
-      "beta[1,2]", "beta[2,2]", "sigma"
+      "alpha[1]",
+      "alpha[2]",
+      "beta[1,1]",
+      "beta[2,1]",
+      "beta[1,2]",
+      "beta[2,2]",
+      "sigma"
     ))),
     3L
   )
@@ -42,7 +47,10 @@ test_that("npars.term scalar", {
 })
 
 test_that("npars.term scalar invalid elements", {
-  expect_warning(expect_identical(npars(new_term(c("a[2]", "b c")), scalar = TRUE), 1L))
+  expect_warning(expect_identical(
+    npars(new_term(c("a[2]", "b c")), scalar = TRUE),
+    1L
+  ))
 })
 
 test_that("npars scalar missing values", {

--- a/tests/testthat/test-npdims.R
+++ b/tests/testthat/test-npdims.R
@@ -6,13 +6,25 @@ test_that("npdims.term", {
   )
   expect_identical(
     npdims(new_term(c(
-      "alpha[1]", "alpha[2]", "beta[1,1]", "beta[2,1]",
-      "beta[1,2]", "beta[2,2]", "sigma"
+      "alpha[1]",
+      "alpha[2]",
+      "beta[1,1]",
+      "beta[2,1]",
+      "beta[1,2]",
+      "beta[2,2]",
+      "sigma"
     ))),
     c(alpha = 1L, beta = 2L, sigma = 1L)
   )
 
-  testthat::expect_error(npdims(new_term(c("alpha[1]", "alpha[3]", "beta[1,1]", "beta[2,1]")), terms = TRUE))
+  testthat::expect_error(npdims(
+    new_term(c("alpha[1]", "alpha[3]", "beta[1,1]", "beta[2,1]")),
+    terms = TRUE
+  ))
 
-  expect_error(npdims(NA_term_), "^`x` must not have any missing values[.]$", class = "chk_error")
+  expect_error(
+    npdims(NA_term_),
+    "^`x` must not have any missing values[.]$",
+    class = "chk_error"
+  )
 })

--- a/tests/testthat/test-pars-terms.R
+++ b/tests/testthat/test-pars-terms.R
@@ -1,7 +1,12 @@
 test_that("pars_term term", {
   terms <- new_term(c(
-    "alpha[1]", "alpha[2]", "beta[1,1]", "beta[2,1]",
-    "beta[1,2]", "beta[2,2]", "sigma"
+    "alpha[1]",
+    "alpha[2]",
+    "beta[1,1]",
+    "beta[2,1]",
+    "beta[1,2]",
+    "beta[2,2]",
+    "sigma"
   ))
   lifecycle::expect_deprecated(pars_terms(terms, scalar = TRUE))
   lifecycle::expect_deprecated(pars_terms(terms, scalar = FALSE))
@@ -13,8 +18,13 @@ test_that("pars_term term", {
 
 test_that("pars_term term_rcrd", {
   terms <- as_term_rcrd(new_term(c(
-    "alpha[1]", "alpha[2]", "beta[1,1]", "beta[2,1]",
-    "beta[1,2]", "beta[2,2]", "sigma"
+    "alpha[1]",
+    "alpha[2]",
+    "beta[1,1]",
+    "beta[2,1]",
+    "beta[1,2]",
+    "beta[2,2]",
+    "sigma"
   )))
   lifecycle::expect_deprecated(pars_terms(terms, scalar = TRUE))
   lifecycle::expect_deprecated(pars_terms(terms, scalar = FALSE))

--- a/tests/testthat/test-pars.R
+++ b/tests/testthat/test-pars.R
@@ -11,8 +11,13 @@ test_that("pars.character", {
 
 test_that("pars.term", {
   terms <- new_term(c(
-    "alpha[1]", "alpha[2]", "beta[1,1]", "beta[2,1]",
-    "beta[1,2]", "beta[2,2]", "sigma"
+    "alpha[1]",
+    "alpha[2]",
+    "beta[1,1]",
+    "beta[2,1]",
+    "beta[1,2]",
+    "beta[2,2]",
+    "sigma"
   ))
   expect_identical(pars(terms), c("alpha", "beta", "sigma"))
   expect_identical(pars(terms, scalar = TRUE), "sigma")
@@ -22,8 +27,13 @@ test_that("pars.term deprecated terms", {
   rlang::local_options(lifecycle_verbosity = "quiet")
 
   terms <- new_term(c(
-    "alpha[1]", "alpha[2]", "beta[1,1]", "beta[2,1]",
-    "beta[1,2]", "beta[2,2]", "sigma"
+    "alpha[1]",
+    "alpha[2]",
+    "beta[1,1]",
+    "beta[2,1]",
+    "beta[1,2]",
+    "beta[2,2]",
+    "sigma"
   ))
 
   lifecycle::expect_deprecated(pars(terms, terms = TRUE))
@@ -38,15 +48,24 @@ test_that("pars.term", {
   expect_identical(pars(new_term(c("b", "b[1]"))), "b")
   expect_identical(pars(new_term(c("b", "b[1]")), scalar = TRUE), "b")
   expect_identical(pars(new_term(c("b", "b[1]", "b[2]"))), "b")
-  expect_identical(pars(new_term(c("b", "b[1]", "b[2]")), scalar = TRUE), character(0))
+  expect_identical(
+    pars(new_term(c("b", "b[1]", "b[2]")), scalar = TRUE),
+    character(0)
+  )
   expect_identical(pars(new_term(c("b[1]", "b[2]"))), "b")
-  expect_identical(pars(new_term(c("b[1]", "b[2]")), scalar = TRUE), character(0))
+  expect_identical(
+    pars(new_term(c("b[1]", "b[2]")), scalar = TRUE),
+    character(0)
+  )
 })
 
 test_that("pars.term missing values", {
   expect_identical(pars(new_term(NA_character_)), NA_character_)
   expect_identical(pars(new_term(c(NA_character_, "a"))), c(NA_character_, "a"))
-  expect_identical(pars(new_term(c("a", NA_character_, "a"))), c("a", NA_character_))
+  expect_identical(
+    pars(new_term(c("a", NA_character_, "a"))),
+    c("a", NA_character_)
+  )
   expect_identical(
     pars(new_term(c(NA_character_, "a", NA_character_, "a"))),
     c(NA_character_, "a")
@@ -83,14 +102,20 @@ test_that("pars scalar = TRUE", {
   expect_identical(pars(new_term(character(0)), scalar = TRUE), character(0))
   expect_identical(pars(new_term("a"), scalar = TRUE), "a")
   expect_identical(pars(new_term(NA_character_), scalar = TRUE), NA_character_)
-  expect_identical(pars(new_term(c(NA_character_, "a")), scalar = TRUE), c(NA_character_, "a"))
+  expect_identical(
+    pars(new_term(c(NA_character_, "a")), scalar = TRUE),
+    c(NA_character_, "a")
+  )
 })
 
 test_that("pars scalar = FALSE", {
   expect_identical(pars(new_term(character(0)), scalar = FALSE), character(0))
   expect_identical(pars(new_term("a"), scalar = FALSE), character(0))
   expect_identical(pars(new_term(NA_character_), scalar = FALSE), NA_character_)
-  expect_identical(pars(new_term(c(NA_character_, "a")), scalar = FALSE), c(NA_character_))
+  expect_identical(
+    pars(new_term(c(NA_character_, "a")), scalar = FALSE),
+    c(NA_character_)
+  )
 })
 
 test_that("pars.default scalar = TRUE", {
@@ -113,16 +138,26 @@ test_that("pars.default scalar = FALSE", {
 
 test_that("pars.term scalar = TRUE", {
   terms <- new_term(c(
-    "alpha[1]", "alpha[2]", "beta[1,1]", "beta[2,1]",
-    "beta[1,2]", "beta[2,2]", "sigma"
+    "alpha[1]",
+    "alpha[2]",
+    "beta[1,1]",
+    "beta[2,1]",
+    "beta[1,2]",
+    "beta[2,2]",
+    "sigma"
   ))
   expect_identical(pars(terms, scalar = TRUE), "sigma")
 })
 
 test_that("pars.term scalar = FALSE", {
   terms <- new_term(c(
-    "alpha[1]", "alpha[2]", "beta[1,1]", "beta[2,1]",
-    "beta[1,2]", "beta[2,2]", "sigma"
+    "alpha[1]",
+    "alpha[2]",
+    "beta[1,1]",
+    "beta[2,1]",
+    "beta[1,2]",
+    "beta[2,2]",
+    "sigma"
   ))
   expect_identical(pars(terms, scalar = FALSE), c("alpha", "beta"))
 })
@@ -132,14 +167,26 @@ test_that("pars.term scalar = TRUE", {
   expect_identical(pars(new_term("b[1]"), scalar = TRUE), "b")
   expect_identical(pars(new_term(c("b", "b[1]")), scalar = TRUE), "b")
   expect_identical(pars(new_term(c("b", "b[1]", "b[2]"))), "b")
-  expect_identical(pars(new_term(c("b", "b[1]", "b[2]")), scalar = TRUE), character(0))
-  expect_identical(pars(new_term(c("b[1]", "b[2]")), scalar = TRUE), character(0))
+  expect_identical(
+    pars(new_term(c("b", "b[1]", "b[2]")), scalar = TRUE),
+    character(0)
+  )
+  expect_identical(
+    pars(new_term(c("b[1]", "b[2]")), scalar = TRUE),
+    character(0)
+  )
 })
 
 test_that("pars.term scalar missing values", {
   expect_identical(pars(new_term(NA_character_), scalar = TRUE), NA_character_)
-  expect_identical(pars(new_term(c(NA_character_, "a")), scalar = TRUE), c(NA_character_, "a"))
-  expect_identical(pars(new_term(c("a", NA_character_, "a")), scalar = TRUE), c("a", NA_character_))
+  expect_identical(
+    pars(new_term(c(NA_character_, "a")), scalar = TRUE),
+    c(NA_character_, "a")
+  )
+  expect_identical(
+    pars(new_term(c("a", NA_character_, "a")), scalar = TRUE),
+    c("a", NA_character_)
+  )
   expect_identical(
     pars(new_term(c(NA_character_, "a", NA_character_, "a")), scalar = TRUE),
     c(NA_character_, "a")

--- a/tests/testthat/test-pdims.R
+++ b/tests/testthat/test-pdims.R
@@ -1,8 +1,13 @@
 test_that("pdims", {
   expect_identical(
     pdims(new_term(c(
-      "alpha[1]", "alpha[2]", "beta[1,1]", "beta[2,1]",
-      "beta[1,2]", "beta[2,2]", "sigma"
+      "alpha[1]",
+      "alpha[2]",
+      "beta[1,1]",
+      "beta[2,1]",
+      "beta[1,2]",
+      "beta[2,2]",
+      "sigma"
     ))),
     list(alpha = 2L, beta = c(2L, 2L), sigma = 1L)
   )
@@ -35,9 +40,14 @@ test_that("pdims", {
 })
 
 test_that("pdims missing value", {
-  expect_error(pdims(NA_term_), "^`x` must not have any missing values[.]$", class = "chk_error")
+  expect_error(
+    pdims(NA_term_),
+    "^`x` must not have any missing values[.]$",
+    class = "chk_error"
+  )
 
-  expect_error(pdims(new_term(c("alpha[3]", "beta[2,1]", NA))),
+  expect_error(
+    pdims(new_term(c("alpha[3]", "beta[2,1]", NA))),
     "^`x` must not have any missing values[.]$",
     class = "chk_error"
   )
@@ -54,8 +64,13 @@ test_that("pdims inconsistent", {
 test_that("pdims.term_rcrd", {
   expect_identical(
     pdims(term_rcrd(c(
-      "alpha[1]", "alpha[2]", "beta[1,1]", "beta[2,1]",
-      "beta[1,2]", "beta[2,2]", "sigma"
+      "alpha[1]",
+      "alpha[2]",
+      "beta[1,1]",
+      "beta[2,1]",
+      "beta[1,2]",
+      "beta[2,2]",
+      "sigma"
     ))),
     list(alpha = 2L, beta = c(2L, 2L), sigma = 1L)
   )

--- a/tests/testthat/test-print.R
+++ b/tests/testthat/test-print.R
@@ -5,8 +5,13 @@ test_that("print", {
     term(alpha = 2, beta = c(2, 2), "sigma")
 
     term(
-      "alpha[1]", "sigma", "alpha[2]", "beta[1,1]", "beta[2,1]",
-      "beta[1,2]", "beta[2,2]"
+      "alpha[1]",
+      "sigma",
+      "alpha[2]",
+      "beta[1,1]",
+      "beta[2,1]",
+      "beta[1,2]",
+      "beta[2,2]"
     )
 
     new_term(c("with space", ""))
@@ -15,7 +20,6 @@ test_that("print", {
 
     term("r  [ 1  ,2  ]")
   })
-
 
   verify_output("out/print-term-rcrd.txt", {
     new_term_rcrd()

--- a/tests/testthat/test-rep.R
+++ b/tests/testthat/test-rep.R
@@ -1,11 +1,17 @@
 test_that("rep term", {
   expect_identical(rep(as_term("a")), as_term("a"))
   expect_identical(rep(as_term("a"), 2), as_term(c("a", "a")))
-  expect_identical(rep(as_term(c("a[2]", "a[1]")), 2), as_term(rep(c("a[2]", "a[1]"), 2)))
+  expect_identical(
+    rep(as_term(c("a[2]", "a[1]")), 2),
+    as_term(rep(c("a[2]", "a[1]"), 2))
+  )
 })
 
 test_that("rep term_rcrd", {
   expect_identical(rep(as_term_rcrd("a")), as_term_rcrd("a"))
   expect_identical(rep(as_term_rcrd("a"), 2), as_term_rcrd(c("a", "a")))
-  expect_identical(rep(as_term_rcrd(c("a[2]", "a[1]")), 2), as_term_rcrd(rep(c("a[2]", "a[1]"), 2)))
+  expect_identical(
+    rep(as_term_rcrd(c("a[2]", "a[1]")), 2),
+    as_term_rcrd(rep(c("a[2]", "a[1]"), 2))
+  )
 })

--- a/tests/testthat/test-repair-terms.R
+++ b/tests/testthat/test-repair-terms.R
@@ -1,5 +1,7 @@
 test_that("repair_terms", {
-  expect_error(repair_terms(NA_character_), "`x` must inherit from S3 class 'term'.",
+  expect_error(
+    repair_terms(NA_character_),
+    "`x` must inherit from S3 class 'term'.",
     class = "chk_error"
   )
   expect_identical(repair_terms(new_term()), new_term())
@@ -25,17 +27,35 @@ test_that("repair_terms", {
   expect_identical(repair_terms(new_term(c("a", ""))), new_term(c("a", NA)))
   expect_identical(repair_terms(new_term(c("a[1]", ""))), new_term(c("a", NA)))
 
-  expect_identical(repair_terms(new_term(c("a[1]", "a[1]"))), new_term(c("a", "a")))
-  expect_identical(repair_terms(new_term(c("a[2]", "a[1]"))), new_term(c("a[2]", "a[1]")))
-  expect_identical(repair_terms(new_term(c("a[2]", "a"))), new_term(c("a[2]", "a[1]")))
+  expect_identical(
+    repair_terms(new_term(c("a[1]", "a[1]"))),
+    new_term(c("a", "a"))
+  )
+  expect_identical(
+    repair_terms(new_term(c("a[2]", "a[1]"))),
+    new_term(c("a[2]", "a[1]"))
+  )
+  expect_identical(
+    repair_terms(new_term(c("a[2]", "a"))),
+    new_term(c("a[2]", "a[1]"))
+  )
 
-  expect_identical(repair_terms(new_term(c("a[2,1]", "a"))), new_term(c("a[2,1]", "a[1]")))
+  expect_identical(
+    repair_terms(new_term(c("a[2,1]", "a"))),
+    new_term(c("a[2,1]", "a[1]"))
+  )
 })
 
 test_that("repair_terms missing values", {
   expect_identical(repair_terms(NA_term_), NA_term_)
-  expect_identical(repair_terms(c(NA_term_, new_term("a"))), new_term(c(NA_term_, "a")))
-  expect_identical(repair_terms(new_term(c("a", NA_term_, "a"))), new_term(c("a", NA_term_, "a")))
+  expect_identical(
+    repair_terms(c(NA_term_, new_term("a"))),
+    new_term(c(NA_term_, "a"))
+  )
+  expect_identical(
+    repair_terms(new_term(c("a", NA_term_, "a"))),
+    new_term(c("a", NA_term_, "a"))
+  )
   expect_identical(
     repair_terms(new_term(c(NA_character_, "a", NA_character_, "a"))),
     new_term(c(NA_term_, "a", NA_term_, "a"))

--- a/tests/testthat/test-scalar-term.R
+++ b/tests/testthat/test-scalar-term.R
@@ -25,7 +25,10 @@ test_that("scalar_term works", {
   expect_identical(scalar_term(new_term(c("a", "a[1]"))), c(TRUE, TRUE))
   expect_identical(scalar_term(new_term(c("a[1]", NA))), c(TRUE, NA))
   expect_identical(scalar_term(new_term(c("a[2]", NA))), c(FALSE, NA))
-  expect_identical(scalar_term(new_term(c("a", "a[2]", "b[1]", "c[1,1]"))), c(FALSE, FALSE, TRUE, FALSE))
+  expect_identical(
+    scalar_term(new_term(c("a", "a[2]", "b[1]", "c[1,1]"))),
+    c(FALSE, FALSE, TRUE, FALSE)
+  )
 })
 
 test_that("scalar_term repair", {

--- a/tests/testthat/test-set-pars.R
+++ b/tests/testthat/test-set-pars.R
@@ -21,9 +21,18 @@ test_that("set_pars", {
     class = "chk_error"
   )
 
-  expect_identical(set_pars(new_term(c("a", "b")), c("b", "a")), new_term(c("b", "a")))
-  expect_identical(set_pars(new_term(c("a", "b")), c("b", "d")), new_term(c("b", "d")))
-  expect_identical(set_pars(new_term(c("a [ 1]", "b")), c("b", "d")), new_term(c("b [ 1]", "d")))
+  expect_identical(
+    set_pars(new_term(c("a", "b")), c("b", "a")),
+    new_term(c("b", "a"))
+  )
+  expect_identical(
+    set_pars(new_term(c("a", "b")), c("b", "d")),
+    new_term(c("b", "d"))
+  )
+  expect_identical(
+    set_pars(new_term(c("a [ 1]", "b")), c("b", "d")),
+    new_term(c("b [ 1]", "d"))
+  )
   expect_error(
     set_pars(new_term(rep("a", 7)), value = c("gamma", "theta", "rho")),
     "^`value` must be length 1, not 3[.]$",
@@ -32,11 +41,14 @@ test_that("set_pars", {
 })
 
 test_that("set_pars missing values", {
-  expect_error(set_pars(new_term(c("a [ 1]", "b")), c("b", NA)),
+  expect_error(
+    set_pars(new_term(c("a [ 1]", "b")), c("b", NA)),
     "^`value` must not have any missing values[.]$",
     class = "chk_error"
   )
-  expect_error(set_pars(NA_term_, "a"), "^`x` must not have any missing values[.]$",
+  expect_error(
+    set_pars(NA_term_, "a"),
+    "^`x` must not have any missing values[.]$",
     class = "chk_error"
   )
   expect_error(
@@ -49,7 +61,8 @@ test_that("set_pars missing values", {
 test_that("set_pars no values", {
   term <- new_term(character(0))
   expect_identical(set_pars(term, character(0)), term)
-  expect_error(set_pars(term, "c"),
+  expect_error(
+    set_pars(term, "c"),
     "^`value` must be length 0, not 1[.]$",
     class = "chk_error"
   )

--- a/tests/testthat/test-subset.R
+++ b/tests/testthat/test-subset.R
@@ -1,31 +1,44 @@
 test_that("subset.term", {
   term <- new_term(c("alpha[1]", "alpha[2]", "sigma"))
   expect_identical(subset(term, character(0)), new_term())
-  expect_error(subset(term, "beta"),
+  expect_error(
+    subset(term, "beta"),
     "^`pars` must match 'alpha' or 'sigma', not 'beta'[.]$",
     class = "chk_error"
   )
   term <- new_term(c(
-    "alpha[1]", "alpha[2]", "beta[1,1]", "beta[2,1]",
-    "beta[1,2]", "beta[2,2]", "sigma"
+    "alpha[1]",
+    "alpha[2]",
+    "beta[1,1]",
+    "beta[2,1]",
+    "beta[1,2]",
+    "beta[2,2]",
+    "sigma"
   ))
   expect_identical(subset(term), term)
   expect_identical(subset(term, "sigma"), new_term("sigma"))
   expect_identical(
     subset(term, c("beta", "sigma")),
     new_term(c(
-      "beta[1,1]", "beta[2,1]",
-      "beta[1,2]", "beta[2,2]", "sigma"
+      "beta[1,1]",
+      "beta[2,1]",
+      "beta[1,2]",
+      "beta[2,2]",
+      "sigma"
     ))
   )
   expect_identical(
     subset(term, c("sigma", "beta")),
     new_term(c(
-      "beta[1,1]", "beta[2,1]",
-      "beta[1,2]", "beta[2,2]", "sigma"
+      "beta[1,1]",
+      "beta[2,1]",
+      "beta[1,2]",
+      "beta[2,2]",
+      "sigma"
     ))
   )
-  expect_error(subset(term, "tt"),
+  expect_error(
+    subset(term, "tt"),
     "^`pars` must match 'alpha', 'beta' or 'sigma', not 'tt'[.]$",
     class = "chk_error"
   )
@@ -34,31 +47,44 @@ test_that("subset.term", {
 test_that("subset.term_rcrd", {
   term_rcrd <- as_term_rcrd(new_term(c("alpha[1]", "alpha[2]", "sigma")))
   expect_identical(subset(term_rcrd, character(0)), new_term_rcrd())
-  expect_error(subset(term_rcrd, "beta"),
+  expect_error(
+    subset(term_rcrd, "beta"),
     "^`pars` must match 'alpha' or 'sigma', not 'beta'[.]$",
     class = "chk_error"
   )
   term_rcrd <- as_term_rcrd(new_term(c(
-    "alpha[1]", "alpha[2]", "beta[1,1]", "beta[2,1]",
-    "beta[1,2]", "beta[2,2]", "sigma"
+    "alpha[1]",
+    "alpha[2]",
+    "beta[1,1]",
+    "beta[2,1]",
+    "beta[1,2]",
+    "beta[2,2]",
+    "sigma"
   )))
   expect_identical(subset(term_rcrd), term_rcrd)
   expect_identical(subset(term_rcrd, "sigma"), as_term_rcrd(new_term("sigma")))
   expect_identical(
     subset(term_rcrd, c("beta", "sigma")),
     as_term_rcrd(new_term(c(
-      "beta[1,1]", "beta[2,1]",
-      "beta[1,2]", "beta[2,2]", "sigma"
+      "beta[1,1]",
+      "beta[2,1]",
+      "beta[1,2]",
+      "beta[2,2]",
+      "sigma"
     )))
   )
   expect_identical(
     subset(term_rcrd, c("sigma", "beta")),
     as_term_rcrd(new_term(c(
-      "beta[1,1]", "beta[2,1]",
-      "beta[1,2]", "beta[2,2]", "sigma"
+      "beta[1,1]",
+      "beta[2,1]",
+      "beta[1,2]",
+      "beta[2,2]",
+      "sigma"
     )))
   )
-  expect_error(subset(term_rcrd, "tt"),
+  expect_error(
+    subset(term_rcrd, "tt"),
     "^`pars` must match 'alpha', 'beta' or 'sigma', not 'tt'[.]$",
     class = "chk_error"
   )
@@ -76,10 +102,13 @@ test_that("subset.term deprecated", {
 
 
 test_that("subset.term missing values", {
-  expect_error(subset(NA_term_), "^`x` must not have any missing values[.]$",
+  expect_error(
+    subset(NA_term_),
+    "^`x` must not have any missing values[.]$",
     class = "chk_error"
   )
-  expect_error(subset(c(NA_term_, new_term("a"))),
+  expect_error(
+    subset(c(NA_term_, new_term("a"))),
     "^`x` must not have any missing values[.]$",
     class = "chk_error"
   )

--- a/tests/testthat/test-term-compat.R
+++ b/tests/testthat/test-term-compat.R
@@ -13,8 +13,16 @@ test_that("term", {
   expect_identical(
     term(10L, "par"),
     new_term(c(
-      "par[1]", "par[2]", "par[3]", "par[4]", "par[5]",
-      "par[6]", "par[7]", "par[8]", "par[9]", "par[10]"
+      "par[1]",
+      "par[2]",
+      "par[3]",
+      "par[4]",
+      "par[5]",
+      "par[6]",
+      "par[7]",
+      "par[8]",
+      "par[9]",
+      "par[10]"
     ))
   )
   expect_identical(term(c(1L, 1L), "par"), new_term("par[1,1]"))
@@ -26,8 +34,14 @@ test_that("term", {
   expect_identical(
     term(c(2L, 2L, 2L), "par2"),
     new_term(c(
-      "par2[1,1,1]", "par2[2,1,1]", "par2[1,2,1]", "par2[2,2,1]",
-      "par2[1,1,2]", "par2[2,1,2]", "par2[1,2,2]", "par2[2,2,2]"
+      "par2[1,1,1]",
+      "par2[2,1,1]",
+      "par2[1,2,1]",
+      "par2[2,2,1]",
+      "par2[1,1,2]",
+      "par2[2,1,2]",
+      "par2[1,2,2]",
+      "par2[2,2,2]"
     ))
   )
 })

--- a/tests/testthat/test-term-rcrd.R
+++ b/tests/testthat/test-term-rcrd.R
@@ -19,7 +19,10 @@ test_that("term_rcrd.list", {
   expect_identical(term_rcrd(x = 1), as_term_rcrd("x"))
   expect_identical(term_rcrd(y = 3), as_term_rcrd(c("y[1]", "y[2]", "y[3]")))
   expect_identical(term_rcrd(y = 1, x = 1), as_term_rcrd(c("y", "x")))
-  expect_identical(term_rcrd(!!!list(y = 1, x = 2)), as_term_rcrd(c("y", "x[1]", "x[2]")))
+  expect_identical(
+    term_rcrd(!!!list(y = 1, x = 2)),
+    as_term_rcrd(c("y", "x[1]", "x[2]"))
+  )
   expect_identical(
     term_rcrd(!!!list(y = c(2L, 2L), x = 2)),
     as_term_rcrd(c("y[1,1]", "y[2,1]", "y[1,2]", "y[2,2]", "x[1]", "x[2]"))

--- a/tests/testthat/test-term.R
+++ b/tests/testthat/test-term.R
@@ -15,8 +15,16 @@ test_that("term", {
   expect_identical(
     term(par = 10L),
     new_term(c(
-      "par[1]", "par[2]", "par[3]", "par[4]", "par[5]",
-      "par[6]", "par[7]", "par[8]", "par[9]", "par[10]"
+      "par[1]",
+      "par[2]",
+      "par[3]",
+      "par[4]",
+      "par[5]",
+      "par[6]",
+      "par[7]",
+      "par[8]",
+      "par[9]",
+      "par[10]"
     ))
   )
   expect_identical(term(par = c(1L, 1L)), new_term("par[1,1]"))
@@ -28,8 +36,14 @@ test_that("term", {
   expect_identical(
     term(par2 = c(2L, 2L, 2L)),
     new_term(c(
-      "par2[1,1,1]", "par2[2,1,1]", "par2[1,2,1]", "par2[2,2,1]",
-      "par2[1,1,2]", "par2[2,1,2]", "par2[1,2,2]", "par2[2,2,2]"
+      "par2[1,1,1]",
+      "par2[2,1,1]",
+      "par2[1,2,1]",
+      "par2[2,2,1]",
+      "par2[1,1,2]",
+      "par2[2,1,2]",
+      "par2[1,2,2]",
+      "par2[2,2,2]"
     ))
   )
 
@@ -48,7 +62,10 @@ test_that("term.list", {
   expect_identical(term(x = 1), new_term("x"))
   expect_identical(term(y = 3), new_term(c("y[1]", "y[2]", "y[3]")))
   expect_identical(term(y = 1, x = 1), new_term(c("y", "x")))
-  expect_identical(term(!!!list(y = 1, x = 2)), new_term(c("y", "x[1]", "x[2]")))
+  expect_identical(
+    term(!!!list(y = 1, x = 2)),
+    new_term(c("y", "x[1]", "x[2]"))
+  )
   expect_identical(
     term(!!!list(y = c(2L, 2L), x = 2)),
     new_term(c("y[1,1]", "y[2,1]", "y[1,2]", "y[2,2]", "x[1]", "x[2]"))

--- a/tests/testthat/test-tindex.R
+++ b/tests/testthat/test-tindex.R
@@ -1,14 +1,22 @@
 test_that("tindex", {
   term <- new_term(c(
-    "alpha[1]", "alpha[2]", "beta[1,1]", "beta[2,1]",
-    "beta[1,2]", "sigma", "beta[2,2]"
+    "alpha[1]",
+    "alpha[2]",
+    "beta[1,1]",
+    "beta[2,1]",
+    "beta[1,2]",
+    "sigma",
+    "beta[2,2]"
   ))
   expect_identical(
     tindex(term),
     list(
-      `alpha[1]` = 1L, `alpha[2]` = 2L,
-      `beta[1,1]` = c(1L, 1L), `beta[2,1]` = 2:1,
-      `beta[1,2]` = 1:2, sigma = 1L,
+      `alpha[1]` = 1L,
+      `alpha[2]` = 2L,
+      `beta[1,1]` = c(1L, 1L),
+      `beta[2,1]` = 2:1,
+      `beta[1,2]` = 1:2,
+      sigma = 1L,
       `beta[2,2]` = c(2L, 2L)
     )
   )
@@ -37,7 +45,13 @@ test_that("tindex", {
   )
 
   expect_identical(
-    tindex(as_term_rcrd(c("alpha", "alpha[2]", "beta[1,1]", "beta[2 ,1  ]", NA))),
+    tindex(as_term_rcrd(c(
+      "alpha",
+      "alpha[2]",
+      "beta[1,1]",
+      "beta[2 ,1  ]",
+      NA
+    ))),
     rlang::set_names(
       list(1L, 2L, c(1L, 1L), 2:1, NA_integer_),
       c("alpha[1]", "alpha[2]", "beta[1,1]", "beta[2,1]", NA)

--- a/tests/testthat/test-unique.R
+++ b/tests/testthat/test-unique.R
@@ -1,5 +1,7 @@
 test_that("unique incomparables", {
-  expect_error(unique(NA_term_, incomparables = TRUE), "^`incomparables` must be FALSE[.]$",
+  expect_error(
+    unique(NA_term_, incomparables = TRUE),
+    "^`incomparables` must be FALSE[.]$",
     class = "chk_error"
   )
 })

--- a/tests/testthat/test-valid-term.R
+++ b/tests/testthat/test-valid-term.R
@@ -1,5 +1,7 @@
 test_that("valid_term character", {
-  expect_error(valid_term(NA_character_), "`x` must inherit from S3 class 'term'[.]",
+  expect_error(
+    valid_term(NA_character_),
+    "`x` must inherit from S3 class 'term'[.]",
     class = "chk_error"
   )
 })
@@ -17,7 +19,15 @@ test_that("valid_term term", {
     rep(TRUE, 3)
   )
   expect_identical(
-    valid_term(new_term(c("", "a b", "a[1]b", "a[0]", "b[1,]", "c[]", "d[1][2]"))),
+    valid_term(new_term(c(
+      "",
+      "a b",
+      "a[1]b",
+      "a[0]",
+      "b[1,]",
+      "c[]",
+      "d[1][2]"
+    ))),
     rep(FALSE, 7L)
   )
   expect_identical(
@@ -29,7 +39,10 @@ test_that("valid_term term", {
 test_that("valid_term term_rcrd", {
   expect_identical(valid_term(new_term_rcrd()), logical(0))
   expect_identical(valid_term(as_term_rcrd(new_term(NA_character_))), NA)
-  expect_identical(valid_term(as_term_rcrd(new_term(c("a", NA_character_)))), c(TRUE, NA))
+  expect_identical(
+    valid_term(as_term_rcrd(new_term(c("a", NA_character_)))),
+    c(TRUE, NA)
+  )
   # expect_identical(
   #   valid_term(as_term_rcrd(new_term(c("a", "a [3]", " b [ 1  ] ", "c[1]")))),
   #   rep(TRUE, 4)
@@ -39,7 +52,15 @@ test_that("valid_term term_rcrd", {
     rep(TRUE, 3)
   )
   expect_identical(
-    valid_term(new_term(c("", "a b", "a[1]b", "a[0]", "b[1,]", "c[]", "d[1][2]"))),
+    valid_term(new_term(c(
+      "",
+      "a b",
+      "a[1]b",
+      "a[0]",
+      "b[1,]",
+      "c[]",
+      "d[1][2]"
+    ))),
     rep(FALSE, 7L)
   )
   expect_identical(

--- a/tests/testthat/test-vld.R
+++ b/tests/testthat/test-vld.R
@@ -4,17 +4,32 @@ test_that("vld_term term", {
   expect_true(vld_term(new_term(character(0))))
   expect_true(vld_term(new_term(NA_character_)))
 
-  lifecycle::expect_deprecated(vld_term(new_term(c("x[2]", "x[1")), validate = "class"))
+  lifecycle::expect_deprecated(vld_term(
+    new_term(c("x[2]", "x[1")),
+    validate = "class"
+  ))
   expect_false(vld_term(new_term(c("x[2]", "x[1")), validate = "valid"))
   expect_true(vld_term(new_term(c("x[2]", "x[1]")), validate = "valid"))
   expect_true(vld_term(new_term(c("x[2]", "x[1,1]")), validate = "valid"))
   expect_false(vld_term(new_term(c("x[2]", "x[1,1]")), validate = "consistent"))
-  expect_true(vld_term(new_term(c("x[2,2]", "x[1,1]")), validate = "consistent"))
+  expect_true(vld_term(
+    new_term(c("x[2,2]", "x[1,1]")),
+    validate = "consistent"
+  ))
   expect_false(vld_term(new_term(c("x[2,2]", "x[1,1]")), validate = "complete"))
   expect_true(vld_term(new_term(c("x[2,1]", "x[1,1]")), validate = "complete"))
-  expect_true(vld_term(new_term(c("x[2,1]", "x[1,1]", "x[1,1]")), validate = "complete"))
-  expect_true(vld_term(new_term(c("x[2,1]", "x[1,1]", "x[1,1]", "x[2,1]")), validate = "complete"))
-  expect_true(vld_term(new_term(c("x[2,1]", "x[1,1]", "x[1,1]", "x[2,1]", NA)), validate = "complete"))
+  expect_true(vld_term(
+    new_term(c("x[2,1]", "x[1,1]", "x[1,1]")),
+    validate = "complete"
+  ))
+  expect_true(vld_term(
+    new_term(c("x[2,1]", "x[1,1]", "x[1,1]", "x[2,1]")),
+    validate = "complete"
+  ))
+  expect_true(vld_term(
+    new_term(c("x[2,1]", "x[1,1]", "x[1,1]", "x[2,1]", NA)),
+    validate = "complete"
+  ))
   rlang::local_options(lifecycle_verbosity = "quiet")
   expect_true(vld_term(new_term(c("x[2]", "x[1")), validate = "class"))
 })
@@ -27,11 +42,32 @@ test_that("vld_term term_rcrd", {
 
   expect_true(vld_term_rcrd(term_rcrd(c("x[2]", "x[1]")), validate = "valid"))
   expect_true(vld_term_rcrd(term_rcrd(c("x[2]", "x[1,1]")), validate = "valid"))
-  expect_false(vld_term_rcrd(term_rcrd(c("x[2]", "x[1,1]")), validate = "consistent"))
-  expect_true(vld_term_rcrd(term_rcrd(c("x[2,2]", "x[1,1]")), validate = "consistent"))
-  expect_false(vld_term_rcrd(term_rcrd(c("x[2,2]", "x[1,1]")), validate = "complete"))
-  expect_true(vld_term_rcrd(term_rcrd(c("x[2,1]", "x[1,1]")), validate = "complete"))
-  expect_true(vld_term_rcrd(term_rcrd(c("x[2,1]", "x[1,1]", "x[1,1]")), validate = "complete"))
-  expect_true(vld_term_rcrd(term_rcrd(c("x[2,1]", "x[1,1]", "x[1,1]", "x[2,1]")), validate = "complete"))
-  expect_true(vld_term_rcrd(term_rcrd(c("x[2,1]", "x[1,1]", "x[1,1]", "x[2,1]", NA)), validate = "complete"))
+  expect_false(vld_term_rcrd(
+    term_rcrd(c("x[2]", "x[1,1]")),
+    validate = "consistent"
+  ))
+  expect_true(vld_term_rcrd(
+    term_rcrd(c("x[2,2]", "x[1,1]")),
+    validate = "consistent"
+  ))
+  expect_false(vld_term_rcrd(
+    term_rcrd(c("x[2,2]", "x[1,1]")),
+    validate = "complete"
+  ))
+  expect_true(vld_term_rcrd(
+    term_rcrd(c("x[2,1]", "x[1,1]")),
+    validate = "complete"
+  ))
+  expect_true(vld_term_rcrd(
+    term_rcrd(c("x[2,1]", "x[1,1]", "x[1,1]")),
+    validate = "complete"
+  ))
+  expect_true(vld_term_rcrd(
+    term_rcrd(c("x[2,1]", "x[1,1]", "x[1,1]", "x[2,1]")),
+    validate = "complete"
+  ))
+  expect_true(vld_term_rcrd(
+    term_rcrd(c("x[2,1]", "x[1,1]", "x[1,1]", "x[2,1]", NA)),
+    validate = "complete"
+  ))
 })


### PR DESCRIPTION
Adds air formatting following the org standard (as in `chk`):

- `air.toml` with the standard `[format]` settings
- `.vscode/` settings recommending and enabling format-on-save with Posit air
- `.Rbuildignore` entries for `air.toml` and `.vscode`
- All R source formatted with `air format .` (air 0.9.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)