### PR TITLE
Update test expectations for chk 0.11.0

### DIFF
--- a/tests/testthat/test-valid-term.R
+++ b/tests/testthat/test-valid-term.R
@@ -1,7 +1,7 @@
 test_that("valid_term character", {
   expect_error(
     valid_term(NA_character_),
-    "`x` must inherit from S3 class 'term'[.]",
+    "`x` must inherit from S3 class 'term'",
     class = "chk_error"
   )
 })


### PR DESCRIPTION
## Summary

chk 0.11.0 (about to be submitted to CRAN) changes the `chkor_vld()` error message format. Each condition now reports the actual class of the object, e.g.

```
At least one of the following conditions must be met:
* `x` must inherit from S3 class 'term', not S3 class 'character'.
* `x` must inherit from S3 class 'term_rcrd', not S3 class 'character'.
```

The expectation in `test-valid-term.R` matched `"\`x\` must inherit from S3 class 'term'[.]"`, which required a literal period immediately after `'term'` and so no longer matches the new message.

## Fix

Drop the trailing `[.]` so the expectation matches the version-stable substring `\`x\` must inherit from S3 class 'term'`, which appears in both the old and new messages.

## Compatibility

The test suite passes with both CRAN chk 0.10.0 and the dev build of chk 0.11.0 (548 passing, 0 failures in each), so this can be merged before or after chk 0.11.0 reaches CRAN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)