### PR TITLE
Escalate pars(terms =) deprecation to error

### DIFF
--- a/R/pars.R
+++ b/R/pars.R
@@ -46,12 +46,8 @@ pars.character <- function(x, scalar = NULL, ...) {
 #' pars(term, scalar = FALSE)
 pars.term <- function(x, scalar = NULL, terms = FALSE, ...) {
   if (!missing(terms)) {
-    deprecate_warn("0.2.1", "term::pars(terms =)")
+    deprecate_stop("0.2.1", "term::pars(terms =)")
   }
-  if (isTRUE(terms)) {
-    return(pars_terms(x))
-  }
-
   pars(as_term_rcrd(x), scalar = scalar, ...)
 }
 

--- a/tests/testthat/_snaps/pars.md
+++ b/tests/testthat/_snaps/pars.md
@@ -1,0 +1,16 @@
+# pars.term deprecated terms
+
+    Code
+      pars(term("a[1]"), terms = TRUE)
+    Condition
+      Error:
+      ! The `terms` argument of `pars()` was deprecated in term 0.2.1 and is now defunct.
+
+---
+
+    Code
+      pars(term("a[1]"), terms = FALSE)
+    Condition
+      Error:
+      ! The `terms` argument of `pars()` was deprecated in term 0.2.1 and is now defunct.
+

--- a/tests/testthat/test-pars.R
+++ b/tests/testthat/test-pars.R
@@ -24,20 +24,8 @@ test_that("pars.term", {
 })
 
 test_that("pars.term deprecated terms", {
-  rlang::local_options(lifecycle_verbosity = "quiet")
-
-  terms <- new_term(c(
-    "alpha[1]",
-    "alpha[2]",
-    "beta[1,1]",
-    "beta[2,1]",
-    "beta[1,2]",
-    "beta[2,2]",
-    "sigma"
-  ))
-
-  lifecycle::expect_deprecated(pars(terms, terms = TRUE))
-  lifecycle::expect_deprecated(pars(terms, terms = FALSE))
+  expect_snapshot(error = TRUE, pars(term("a[1]"), terms = TRUE))
+  expect_snapshot(error = TRUE, pars(term("a[1]"), terms = FALSE))
 })
 
 test_that("pars.term", {


### PR DESCRIPTION
The `terms` argument of `pars()` has warned via `deprecate_warn("0.2.1")` since term 0.3.0 (September 2020), well past the one-year escalation threshold.

- Convert `deprecate_warn()` to `deprecate_stop()` for `pars(terms =)`
- Remove the now-unreachable `pars_terms()` dispatch branch
- Replace the `expect_deprecated()` tests with error snapshots matching the pattern in `test-deprecated.R`

Part of the 0.4.0 release preparation (#105).

🤖 Generated with [Claude Code](https://claude.com/claude-code)